### PR TITLE
fixes issue #1

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -180,6 +180,19 @@ Run an execution using a specified recipe on a server or multiple groups of serv
 
 ### <POST> /recipes/@recipe-id/execute [POST]
 
++ Request (application/json)
+    + Headers
+    
+            X-Commando-API-Version: v1
+
+    + Body
+
+        {
+          "server": "<server-id>",
+          "halt_on_stderr": false,
+          "notes": "Some notes go here."
+        }
+
 ### Post Parameters
 
 + **server** *(required one of server or groups)* ... A single server id. You may find server ids in the modal popup when clicking a server in the Commando.io web interface.


### PR DESCRIPTION
Added a request body for <POST> /recipes/@recipe-id/execute

Ideally the API would be changed in the future so that mutually-exclusive attributes (eg "server" and "groups") are not part of the same request body.  This is an antipattern.
